### PR TITLE
Fix broken make - patch for dmd 2.076

### DIFF
--- a/lib/http/parser/core.d
+++ b/lib/http/parser/core.d
@@ -117,7 +117,7 @@ public struct HttpBodyChunk {
         bool _isFinal;
 
     public:
-        this(ubyte[] buffer, bool isFinal) 
+        this(ubyte[] buffer, bool isFinal)
         {
             _buffer = buffer;
             _isFinal = isFinal;
@@ -187,7 +187,7 @@ public class HttpParser {
     }
 
     void _resetCurrentHeader() {
-      clear(_currentHeader);
+      destroy(_currentHeader);
     }
     /** End Counters **/
   }
@@ -326,7 +326,7 @@ public class HttpParser {
       }
       return CB_OK;
     }
-    
+
     int _on_message_complete() {
       if(this._messageComplete) {
         try {
@@ -354,7 +354,7 @@ public class HttpParser {
       }
       return CB_OK;
     }
-    
+
     int _on_url(ubyte[] data) {
       if(this._onUrl) {
         try {
@@ -366,7 +366,7 @@ public class HttpParser {
       }
       return CB_OK;
     }
-    
+
     int _on_header_field(ubyte[] data) {
       if(_currentHeader.hasValue) {
         int res = _safePublishHeader();

--- a/test/testutil.d
+++ b/test/testutil.d
@@ -17,7 +17,7 @@ void scopeTest(string name, void delegate() cb) {
 
 void scopeWritefln(S...)(S args) {
   write(scopeTabs());
-  writefln!S(args);
+  writefln(args);
 }
 
 void runTest(string title, void delegate() cb, string file = __FILE__, size_t line = __LINE__) {


### PR DESCRIPTION
When trying to build this project for the current version of dmd you get some errors. This patch will fix them so that `make` and `make test` work again.